### PR TITLE
Altera o type das props de estilo do SearchAutocomple para array

### DIFF
--- a/src/components/common/Autocomplete/Autocomplete.vue
+++ b/src/components/common/Autocomplete/Autocomplete.vue
@@ -115,18 +115,18 @@
       },
 
       inputClass: {
-        type: String,
-        default: '',
+        type: Array,
+        default: () => [],
       },
 
       listClass: {
-        type: String,
-        default: '',
+        type: Array,
+        default: () => [],
       },
 
       listItemClass: {
-        type: String,
-        default: '',
+        type: Array,
+        default: () => [],
       },
 
       inputName: {


### PR DESCRIPTION
Como as props estavam definidas como `String`, não era possível passar uma array de classes pela prop.