### PR TITLE
Escapa termo na regex

### DIFF
--- a/src/components/common/Autocomplete/Autocomplete.spec.js
+++ b/src/components/common/Autocomplete/Autocomplete.spec.js
@@ -458,6 +458,12 @@ describe('Autocomplete component', () => {
 
         expect(wrapper.vm.highlighter({ term: 'con', word: 'consulta remédios' })).toEqual('<strong>con</strong>sulta remédios');
       });
+
+      it('escapes the typed term', () => {
+        const wrapper = shallowAutocomplete();
+
+        expect(wrapper.vm.highlighter({ term: 'Viagra (', word: 'Viagra (20mg)' })).toEqual('<strong>Viagra (</strong>20mg)');
+      });
     });
   });
 });

--- a/src/components/common/Autocomplete/Autocomplete.vue
+++ b/src/components/common/Autocomplete/Autocomplete.vue
@@ -215,7 +215,7 @@
       },
 
       highlighter({ term, word }) {
-        return word.replace(new RegExp(term, 'gi'), match => `<strong>${match}</strong>`);
+        return word.replace(new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), match => `<strong>${match}</strong>`);
       },
 
       populateTerm() {


### PR DESCRIPTION
Como esse termo é digitado pelo usuario, tinha momentos que ele digitava termo que acabava quebrando o highlight.