### PR TITLE
Emite evento sempre que o usario digita algo e passar a verificação do showSuggestions para o ul

### DIFF
--- a/src/components/common/Autocomplete/Autocomplete.spec.js
+++ b/src/components/common/Autocomplete/Autocomplete.spec.js
@@ -148,7 +148,7 @@ describe('Autocomplete component', () => {
 
       wrapper.find(BaseInput).vm.$emit('focus');
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('focus');
     });
 
@@ -166,7 +166,7 @@ describe('Autocomplete component', () => {
         event: { code: 'Escape' },
       });
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('escape');
     });
 
@@ -183,7 +183,7 @@ describe('Autocomplete component', () => {
 
       wrapper.find(Autocomplete).vm.$emit('close');
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('close');
     });
 
@@ -237,6 +237,18 @@ describe('Autocomplete component', () => {
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('change', {
         highlight: '<strong>Ibu</strong>profeno 50mg', name: 'Ibuprofeno 50mg', permalink: '/p/ibruprofeno-50', selected: false,
       });
+    });
+
+    it('emits event "inputChanged" when users when users search for term', () => {
+      const wrapper = shallowAutocomplete();
+      jest.spyOn(wrapper.vm, '$emit');
+
+      wrapper.find(BaseInput).vm.$emit('change', {
+        value: 'ibu',
+      });
+
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledWith("inputChanged", "ibu");
     });
   });
 
@@ -295,7 +307,7 @@ describe('Autocomplete component', () => {
         event: { code: 'Enter' },
       });
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('change', {
         highlight: '<strong>Ibu</strong>profeno 150mg', name: 'Ibuprofeno 150mg', permalink: '/p/ibruprofeno-150', selected: true,
       });
@@ -306,7 +318,7 @@ describe('Autocomplete component', () => {
         event: { code: 'Enter' },
       });
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('submit', 'ibu');
     });
 
@@ -319,7 +331,7 @@ describe('Autocomplete component', () => {
         event: { code: 'Tab' },
       });
 
-      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
       expect(wrapper.vm.$emit).toHaveBeenCalledWith('change', {
         highlight: '<strong>Ibu</strong>profeno 150mg', name: 'Ibuprofeno 150mg', permalink: '/p/ibruprofeno-150', selected: true,
       });
@@ -374,7 +386,7 @@ describe('Autocomplete component', () => {
       it('when input in slot is focused', () => {
         wrapper.find('input').trigger('focus');
 
-        expect(wrapper.vm.$emit).toHaveBeenCalledTimes(1);
+        expect(wrapper.vm.$emit).toHaveBeenCalledTimes(2);
         expect(wrapper.vm.$emit).toHaveBeenCalledWith('focus');
         expect(wrapper.element).toMatchSnapshot();
       });

--- a/src/components/common/Autocomplete/Autocomplete.vue
+++ b/src/components/common/Autocomplete/Autocomplete.vue
@@ -32,11 +32,12 @@
       </button>
     </slot>
     <div
-      v-if="showSuggestions && expanded"
+      v-if="expanded"
       :class="[$style.expandedContainer, expandedClass]"
     >
       <ul
         :class="[$style.suggestions, listClass]"
+        v-if="showSuggestions"
         data-suggestions
       >
         <li
@@ -225,6 +226,7 @@
 
       onInputChange(ev) {
         this.value = ev.value;
+        this.$emit('inputChanged', this.value);
 
         if (
           this.suggestionsCache[this.cacheKey] &&

--- a/src/components/common/Autocomplete/__snapshots__/Autocomplete.spec.js.snap
+++ b/src/components/common/Autocomplete/__snapshots__/Autocomplete.spec.js.snap
@@ -24,7 +24,14 @@ exports[`Autocomplete component #events emits event "change" when users clicks i
     />
   </button>
    
-  <!---->
+  <div
+    class="expandedContainer"
+  >
+    <!---->
+     
+    <!---->
+     
+  </div>
 </div>
 `;
 
@@ -155,7 +162,12 @@ exports[`Autocomplete component matches the snapshot when component is mounted 1
     />
   </button>
    
-  <!---->
+  <div
+    class="expandedContainer"
+  >
+    <!---->
+      
+  </div>
 </div>
 `;
 
@@ -362,7 +374,7 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -7,19 +7,78 @@
+@@ -7,11 +7,11 @@
       model=""
       name="searchInput"
       placeholder=""
@@ -375,14 +387,12 @@ Snapshot Diff:
     <button
       class="buttonSearch"
       type="submit"
-    >
-      <baseicon-stub
-        id="search.icon.svg"
+@@ -21,10 +21,64 @@
       />
     </button>
-+    
-+   <div
-+     class="expandedContainer"
+     
+    <div
+      class="expandedContainer"
 +   >
 +     <ul
 +       class="suggestions"
@@ -398,7 +408,7 @@ Snapshot Diff:
 +           </strong>
 +           profeno 25mg
 +         </span>
-           
++          
 +         <baseicon-stub
 +           class="suggestionIcon"
 +           id="next.icon.svg"
@@ -423,7 +433,7 @@ Snapshot Diff:
 +       <li
 +         class="suggestion"
 +         data-suggestion-value="2"
-+       >
+        >
 +         <span>
 +           <strong>
 +             Ibu
@@ -439,8 +449,9 @@ Snapshot Diff:
 +     </ul>
 +      
       <!---->
+-       
 +      
-+   </div>
+    </div>
   </div>
 `;
 
@@ -911,15 +922,12 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -19,51 +19,7 @@
-      <baseicon-stub
-        id="search.icon.svg"
-      />
+@@ -22,48 +22,11 @@
     </button>
      
--   <div
--     class="expandedContainer"
--   >
+    <div
+      class="expandedContainer"
+    >
 -     <ul
 -       class="suggestions"
 -       data-suggestions=""
@@ -958,10 +966,11 @@ Snapshot Diff:
 -         </span>
 -       </li>
 -     </ul>
--      
-    <!---->
--      
--   </div>
++     <!---->
+       
+      <!---->
+       
+    </div>
   </div>
 `;
 
@@ -1076,15 +1085,12 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -19,66 +19,7 @@
-      <baseicon-stub
-        id="search.icon.svg"
-      />
+@@ -22,63 +22,11 @@
     </button>
      
--   <div
--     class="expandedContainer"
--   >
+    <div
+      class="expandedContainer"
+    >
 -     <ul
 -       class="suggestions"
 -       data-suggestions=""
@@ -1138,9 +1144,10 @@ Snapshot Diff:
 -         />
 -       </li>
 -     </ul>
--      
-    <!---->
--      
--   </div>
++     <!---->
+       
+      <!---->
+       
+    </div>
   </div>
 `;


### PR DESCRIPTION
 - Queremos que os outros slots(placeholderSuggestion e footerListSuggestions) sejam exibidos mesmo quando nao tiver suggestions disponiveis, com isso, a condição do showSuggestions foi movida para o ul

- Como o `getSuggestions` so era chamado quando nao tinha o term no cache ou o term fosse menor que 3, acontecia do watch na prop term nao funcionar corretamente, por que o `getSuggestions` nao estava sendo chamado.