### PR TITLE
Ajusta typo

### DIFF
--- a/src/components/common/BaseModal/BaseModal.vue
+++ b/src/components/common/BaseModal/BaseModal.vue
@@ -7,7 +7,7 @@
       <div :class="[$style.container, 'cr-base-modal__container']" data-modal-container>
         <div :class="[$style.content, 'cr-base-modal__content']" data-modal-content>
           <button v-if="dismissible" data-modal-close
-            :class="[$style.closeButton, 'cr-base-modall__close']"
+            :class="[$style.closeButton, 'cr-base-modal__close']"
             @click="$emit('close')"
           >
             <span :class="$style.closeButtonLabel">Fechar</span>

--- a/src/components/common/BaseModal/__snapshots__/BaseModal.spec.js.snap
+++ b/src/components/common/BaseModal/__snapshots__/BaseModal.spec.js.snap
@@ -16,7 +16,7 @@ exports[`BaseModal Component When rendered matches to snapshot 1`] = `
       data-modal-content=""
     >
       <button
-        class="closeButton cr-base-modall__close"
+        class="closeButton cr-base-modal__close"
         data-modal-close=""
       >
         <span


### PR DESCRIPTION
O modal do `cr-base-modal__close` estava escrito com 2 `l`