### PR TITLE
Corrige mixin que injeta todos os ícones na doc

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -3,7 +3,6 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
   styleguideDir: '../public',
-  mixins: ['./styleguide/icons-mixin.js'],
   sections: [{
     name: 'Components',
     components: '../src/components/**/[A-Z]*.vue'
@@ -27,7 +26,10 @@ module.exports = {
     }]
   }],
   showUsage: true,
-  require: ['./src/style.css'],
+  require: [
+    './src/style.css',
+    path.join(__dirname, 'styleguide/icons-mixin.js')
+  ],
   webpackConfig: {
     module: {
       rules: [

--- a/config/styleguide/icons-mixin.js
+++ b/config/styleguide/icons-mixin.js
@@ -1,3 +1,5 @@
+import Vue from 'vue'
+
 import favorite from './../../src/icons/favorite.icon.svg';
 import favoriteFill from './../../src/icons/favorite-fill.icon.svg';
 import gallery from './../../src/icons/gallery.icon.svg';
@@ -80,7 +82,7 @@ import youtube from './../../src/icons/youtube.icon.svg';
 import target from './../../src/icons/target.icon.svg';
 import loader from './../../src/icons/loader.icon.svg';
 
-const icons = [
+const allIcons = [
   favorite,
   favoriteFill,
   mosaic,
@@ -163,14 +165,14 @@ const icons = [
   leafletResume,
 ];
 
-export default {
+Vue.mixin({
   data() {
-    return { icons };
+    return { allIcons };
   },
 
   methods: {
     $getIcon(name) {
-      return this.icons.find((icon) => icon.id === `${name}.icon`);
+      return this.allIcons.find((icon) => icon.id === `${name}.icon`);
     }
   }
-};
+});

--- a/src/components/common/BaseButton/BaseButton.md
+++ b/src/components/common/BaseButton/BaseButton.md
@@ -117,8 +117,8 @@ Add a icon in button
   const getIcon = (icons, name) => icons.find((icon) => icon.id === `${name}.icon`);
 
   <div>
-      <BaseButton size="small" :icon="getIcon(icons, 'info')" type="success">Button success</BaseButton>
-      <BaseButton size="medium" :icon="getIcon(icons, 'cancel')" type="neutral">Button success</BaseButton>
-      <BaseButton size="large" :icon="getIcon(icons, 'change')" type="warning">Button success</BaseButton>
+      <BaseButton size="small" :icon="getIcon(allIcons, 'info')" type="success">Button success</BaseButton>
+      <BaseButton size="medium" :icon="getIcon(allIcons, 'cancel')" type="neutral">Button success</BaseButton>
+      <BaseButton size="large" :icon="getIcon(allIcons, 'change')" type="warning">Button success</BaseButton>
   </div>
 ```

--- a/src/components/common/BaseIcon/BaseIcon.md
+++ b/src/components/common/BaseIcon/BaseIcon.md
@@ -42,7 +42,7 @@ import favorite from 'cr-ui/src/icons/favorite.icon.svg';
 
 ```js
 <div>
-  <div v-for="icon in icons" :style="{ display: 'inline-block', padding: '15px 0', width: '33%' }">
+  <div v-for="icon in allIcons" :style="{ display: 'inline-block', padding: '15px 0', width: '33%' }">
     <BaseIcon :id="icon.id"/>
     <span>src/icons/{{icon.id}}.svg</span>
   </div>

--- a/src/components/common/BaseNotice/BaseNotice.md
+++ b/src/components/common/BaseNotice/BaseNotice.md
@@ -20,7 +20,7 @@ const getIcon = (icons, name) => icons.find((icon) => icon.id === `${name}.icon`
     title="Something wrong happened"
     message="Lorem ipsum dolor!!"
     type="danger"
-    :icon="getIcon(icons, 'warning')"
+    :icon="getIcon(allIcons, 'warning')"
   />
 
   <br />
@@ -29,7 +29,7 @@ const getIcon = (icons, name) => icons.find((icon) => icon.id === `${name}.icon`
     title="Sorry, you got an error!"
     message="Lorem ipsum dolor sit amet"
     type="warning"
-    :icon="getIcon(icons, 'info')"
+    :icon="getIcon(allIcons, 'info')"
   />
 
   <br />
@@ -37,7 +37,7 @@ const getIcon = (icons, name) => icons.find((icon) => icon.id === `${name}.icon`
   <BaseNotice
     title="Congrats all works!"
     type="success"
-    :icon="getIcon(icons, 'thumb-up')"
+    :icon="getIcon(allIcons, 'thumb-up')"
   />
 
   <br />
@@ -46,7 +46,7 @@ const getIcon = (icons, name) => icons.find((icon) => icon.id === `${name}.icon`
     title="Something wrong happened"
     message="Lorem ipsum dolor?"
     type="info"
-    :icon="getIcon(icons, 'help')"
+    :icon="getIcon(allIcons, 'help')"
   />
 
 

--- a/src/components/common/FormError/FormError.vue
+++ b/src/components/common/FormError/FormError.vue
@@ -6,7 +6,7 @@
 
     <div :class="$style.errorsBlock">
       <ul :class="$style.errorList">
-        <li v-for="(error, index) in errorList.withKeys" :key="index">
+        <li v-for="(error, index) in errorList.withKeys" :key="'withKeys-' + index">
           {{error.field}}
 
           <ul :class="$style.fieldErrorList">
@@ -16,7 +16,7 @@
           </ul>
         </li>
 
-        <li v-for="(error, index) in errorList.withoutKeys" :key="index">
+        <li v-for="(error, index) in errorList.withoutKeys" :key="'withoutKeys-' + index">
           {{error}}
         </li>
       </ul>


### PR DESCRIPTION
Após atualizar as dependências do projeto os ícones da documentação pararam de ser exibidos.

Esse PR refatora a forma de injetar o mixin na documentação.

ps.: Esse PR não tem nenhum impacto na versão do projeto em si, pois altera apenas a sua documentação.