### PR TITLE
Passa evento para função da diretiva click-outside

### DIFF
--- a/src/directives/click-outside/index.js
+++ b/src/directives/click-outside/index.js
@@ -10,7 +10,7 @@ const documentHandler = el => (event) => {
   }
 
   if (typeof el[ctx].bindingFn === 'function') {
-    el[ctx].bindingFn();
+    el[ctx].bindingFn(event);
   }
 };
 


### PR DESCRIPTION
- Passa o evento para a função chamada na diretiva `click-outside`. 