### PR TITLE
Utiliza ícone chevron no lugar do next no BaseSelect

### DIFF
--- a/src/components/common/BaseSelect/BaseSelect.vue
+++ b/src/components/common/BaseSelect/BaseSelect.vue
@@ -55,7 +55,7 @@
 <script>
   import clickOutside from './../../../directives/click-outside';
   import BaseIcon from '../BaseIcon';
-  import nextIcon from '../../../icons/next.icon.svg';
+  import nextIcon from '../../../icons/chevron-right.icon.svg';
 
   export default {
     name: 'BaseSelect',

--- a/src/components/common/BaseSelect/__snapshots__/BaseSelect.spec.js.snap
+++ b/src/components/common/BaseSelect/__snapshots__/BaseSelect.spec.js.snap
@@ -21,7 +21,7 @@ exports[`BaseSelect matches the snapshot when component is mounted 1`] = `
    
   <baseicon-stub
     class="cr-base-select__svg arrowDown"
-    id="next.icon.svg"
+    id="chevron-right.icon.svg"
   />
    
   <div


### PR DESCRIPTION
O ícone do BaseSelect estava errado.