### PR TITLE
Corrige método que fechava o BaseSelect

### DIFF
--- a/src/components/common/BaseSelect/BaseSelect.vue
+++ b/src/components/common/BaseSelect/BaseSelect.vue
@@ -147,16 +147,16 @@
       },
 
       onPressEsc(e) {
-        this.closeSelect(e.currentTarget);
+        this.closeSelect();
+
+        if (e.currentTarget) {
+          e.currentTarget.blur();
+        }
       },
 
-      closeSelect($input = null) {
+      closeSelect() {
         this.isOpen = false;
         this.hovered = null;
-
-        if ($input) {
-          $input.blur();
-        }
       },
 
       navigateUp() {


### PR DESCRIPTION
O método `closeSelect` estava sendo chamado tanto pelo `v-click-outside` quanto por outros métodos do componente, porém quando era chamado pelo `v-click-outside` ele estava recebendo o evento que disparou a diretiva, conforme fizemos em https://github.com/ConsultaRemedios/cr-ui/pull/29, o problema é que o `closeSelect` não estava preparado para receber um evento como parâmetro.

Esse PR refatora o `closeSelect` pra ele não receber nenhum parâmetro.