### PR TITLE
Passa a permitir receber String como Number na prop value

### DIFF
--- a/src/components/common/BaseRadioButton/BaseRadioButton.vue
+++ b/src/components/common/BaseRadioButton/BaseRadioButton.vue
@@ -31,7 +31,7 @@
       },
 
       value: {
-        type: String,
+        type: [String, Number],
         required: true,
       },
 


### PR DESCRIPTION
Ocorreu a situação de precisarmos passar um number pra prop value e ela só permitia String. Também acredito que faço mais sentido poder tanto string como number para o value.