### PR TITLE
feat: adiciona cores de cupom e promoção

### DIFF
--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -23,6 +23,9 @@
   --cta-primary: #fa503f;
   --cta-secundary: #d30b3f;
 
+  --promotion-color: #008554;
+  --coupon-color: #6a5cd4;
+
   --classification-generic: #f9ad3d;
   --classification-beauty: #ff4d8d;
   --classification-new: #bfd72f;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -24,7 +24,9 @@
   --cta-secundary: #d30b3f;
 
   --promotion-color: #008554;
+  --promotion-color-hover: #005F3C;
   --coupon-color: #6a5cd4;
+  --coupon-color-hover: #483ca7;
 
   --classification-generic: #f9ad3d;
   --classification-beauty: #ff4d8d;


### PR DESCRIPTION
Estão faltando cores pra definir as promoções e os cupons no portal, esse PR tem como objetivo criar essas cores.

ref: https://sprints.zoho.com/team/consultaremedios#itemdetails/P10/I244

------------------------------------------------------------

### Screenshots

Não se aplica.

### Browsers Testados

Não se aplica.

### Breakpoints Testados

Não se aplica.
