### PR TITLE
fix(autocomplete): corrige o value utilizado no onInputChange

### DIFF
--- a/src/components/common/Autocomplete/Autocomplete.vue
+++ b/src/components/common/Autocomplete/Autocomplete.vue
@@ -226,7 +226,7 @@ export default {
     },
 
     onInputChange(ev) {
-      const value = ev.value;
+      const { value } = ev;
       this.value = value;
       this.$emit('inputChanged', value);
 

--- a/src/components/common/Autocomplete/Autocomplete.vue
+++ b/src/components/common/Autocomplete/Autocomplete.vue
@@ -226,38 +226,39 @@ export default {
     },
 
     onInputChange(ev) {
-      this.value = ev.value;
-      this.$emit('inputChanged', this.value);
+      const value = ev.value;
+      this.value = value;
+      this.$emit('inputChanged', value);
 
       if (
         this.suggestionsCache[this.cacheKey]
-          && this.suggestionsCache[this.cacheKey][this.value]
-          && this.suggestionsCache[this.cacheKey][this.value].length > 0
+          && this.suggestionsCache[this.cacheKey][value]
+          && this.suggestionsCache[this.cacheKey][value].length > 0
       ) {
-        this.suggestions = this.suggestionsCache[this.cacheKey][this.value];
+        this.suggestions = this.suggestionsCache[this.cacheKey][value];
         this.showSuggestions = true;
         return;
       }
 
-      if (this.value && this.value.length >= 3) {
+      if (value && value.length >= 3) {
         if (this.$slots.placeholderSuggestion) this.suggestions = [];
 
         this.showSuggestions = true;
-        this.inputedTerm = ev.value;
+        this.inputedTerm = value;
         Promise.resolve(this.getSuggestions(ev)).then((suggestions) => {
           this.showSuggestions = true;
           this.suggestions = suggestions.map((suggestion) => ({
             ...suggestion,
             highlight: this.highlighter({
-              term: this.value,
+              term: value,
               word: suggestion[this.suggestionKey],
             }),
             selected: false,
           }));
           if (this.suggestionsCache[this.cacheKey]) {
-            this.suggestionsCache[this.cacheKey][this.value] = this.suggestions;
+            this.suggestionsCache[this.cacheKey][value] = this.suggestions;
           } else {
-            this.suggestionsCache[this.cacheKey] = { [this.value]: this.suggestions };
+            this.suggestionsCache[this.cacheKey] = { [value]: this.suggestions };
           }
         }).catch(() => {
           if (this.$slots.placeholderSuggestion) this.suggestions = [];


### PR DESCRIPTION
Corrige o cache do componente de autocomplete.
Antes nós utilizavámos o `this.value` (estado do componente) para atualizar o cache, mas quando o usuário digitava muito rápido, gerava inconsistência com o valor buscado e o valor utilizado na Promise para efetuar a busca.

ref: https://sprints.zoho.com/team/consultaremedios#itemdetails/P10/I199

### Browsers Testados

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] IE
- [ ] Mobile

### Breakpoints Testados

- [x] Desktop(1280x800)
- [x] Tablet(1024x768)
- [x] Mobile(320x568)
