### PR TITLE
fix: desabilita o esModule do file-loader

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -63,7 +63,10 @@ module.exports = {
         {
           test: /\.(svg|eot|otf|ttf|woff|woff2|png)$/i,
           exclude: ['/node_modules/', path.resolve(__dirname, '../src/icons/')],
-          loader: 'file-loader'
+          loader: 'file-loader',
+          options: {
+            esModule: false,
+          },
         },
         {
           test: /\.icon\.svg$/,


### PR DESCRIPTION
### Descrição

No passado nós atualizamos as dependências do projeto e consequentemente atualizamos o `file-loader`, mas nas versões mais novas o `file-loader` retorna por padrão esModules, e isso fez com que nossas imagens quebrassem, para manter como anteriomente foi desabilitado a geração de esModules. 

doc file-loader: https://github.com/webpack-contrib/file-loader#esmodule

------------------------------------------------------------

### Screenshots
Antes:
![image](https://user-images.githubusercontent.com/10675595/110468876-a75a1000-80b7-11eb-841b-82a49d4989a3.png)

Depois
![image](https://user-images.githubusercontent.com/10675595/110468780-8396ca00-80b7-11eb-933f-2bf03989cd54.png)

...

### Navegadores testados

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE
- [ ] Mobile

### Breakpoints testados

- [x] Desktop(1280x800)
- [ ] Tablet(1024x768)
- [ ] Mobile(320x568)
