### PR TITLE
feat: utiliza variaveis de cores no BaseCheckbox

### DIFF
--- a/src/components/common/BaseCheckbox/BaseCheckbox.vue
+++ b/src/components/common/BaseCheckbox/BaseCheckbox.vue
@@ -89,12 +89,12 @@ export default {
   }
 
   .wrapper:hover::before {
-    border: 1px solid #138484;
+    border: 1px solid var(--link-color);
   }
 
   .wrapper.isSelected::before {
-    border-color: #138484;
-    background-color: #138484;
+    border-color: var(--link-color);
+    background-color: var(--link-color);
   }
 
   .wrapper.isDisabled::before {


### PR DESCRIPTION
### Descrição

Para o whitelabel mudar a cor dos componentes precisamos que todos utilizem variaveis de cores. Esse PR muda as cores do BaseCheckbox para variaveis.


task: https://sprints.zoho.com/team/consultaremedios#itemdetails/P21/I72

### Screenshots
Sem whitelabel o componente esta com a cor certa da variavel:
![2021-08-11_07-57](https://user-images.githubusercontent.com/65905199/129017725-8a82c490-9526-4ac8-813e-84d5de48aa61.png)


Com whitelabel o consultaremedios vai alterar  a variavel:
![2021-08-11_07-55](https://user-images.githubusercontent.com/65905199/129017520-457d2c8a-9b96-48dc-9940-43307cc1831d.png)
...

### Navegadores testados

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE
- [ ] Mobile

### Breakpoints testados

- [x] Desktop(1280x800)
- [x] Tablet(1024x768)
- [x] Mobile(320x568)
