### PR TITLE
feat: altera tipos aceitos pela props value do CardRadioButton.vue

### DIFF
--- a/src/components/common/CardRadioButton/CardRadioButton.vue
+++ b/src/components/common/CardRadioButton/CardRadioButton.vue
@@ -38,7 +38,7 @@ export default {
       default: false,
     },
     value: {
-      type: String,
+      type: [String, Number],
       required: true,
     },
     name: {


### PR DESCRIPTION
### Descrição
Neste PR alteramos a props `value` para aceitar string ou number.

task: [URL DA TASK](https://sprints.zoho.com/team/consultaremedios#itemdetails/P21/I360)
